### PR TITLE
Fixes typo in installation docs. 

### DIFF
--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -10,7 +10,7 @@ Servee is a special purpose django-admin for editing content on the front end of
 First you should put servee in your environment:
 
     pip install django-servee
-    
+
 We're also keeping a [dist server of our own][1].
 
 [1]: http://dist.servee.com/dev/
@@ -29,16 +29,16 @@ to wysiwyg areas, and that's awesome (sometimes).
     INSTALLED_APPS += [
         "servee.frontendadmin",
         "servee.wysiwyg",
-        "servee.wysiwyg.tinymce", 
+        "servee.wysiwyg.tinymce",
     ]
 
 Then syncdb.  Servee assumes that you're using either contrib.staticfiles or django-staticfiles (>=1.1)
 Make sure that you collectstatic in production.
 
 It's important to add servee urls, and you probably want to use autodiscover.
-    
+
     from servee import frontendadmin
-    frontendadmin.site.autodiscover()
+    frontendadmin.autodiscover()
     # ...
     url(r"^servee/", include(frontendadmin.site.urls)),
 

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -5,17 +5,15 @@ Installation
 
 Servee is a special purpose django-admin for editing content on the front end of your site.
 
-* Docs at [Read The Docs][rtd]
+* Docs at `Read The Docs <http://django-servee.readthedocs.org/en/latest/index.html>`_.
 
-First you should put servee in your environment:
+First you should put servee in your environment::
 
     pip install django-servee
 
-We're also keeping a [dist server of our own][1].
+We're also keeping a `dist server of our_own <http://dist.servee.com/dev/>`_.
 
-[1]: http://dist.servee.com/dev/
-
-or download and
+or download and::
 
     ./setup.py develop
 
@@ -24,7 +22,7 @@ Then add servee to your installed apps.
 At a minimum, you want to install `servee.frontendadmin`.  This is
 the admin site.  You probably also want our wysiwyg tools, and the tinymce
 backend (only supported wysiwyg editor at the moment) This converts your textareas
-to wysiwyg areas, and that's awesome (sometimes).
+to wysiwyg areas, and that's awesome (sometimes)::
 
     INSTALLED_APPS += [
         "servee.frontendadmin",
@@ -35,13 +33,11 @@ to wysiwyg areas, and that's awesome (sometimes).
 Then syncdb.  Servee assumes that you're using either contrib.staticfiles or django-staticfiles (>=1.1)
 Make sure that you collectstatic in production.
 
-It's important to add servee urls, and you probably want to use autodiscover.
+It's important to add servee urls, and you probably want to use autodiscover::
 
     from servee import frontendadmin
     frontendadmin.autodiscover()
     # ...
     url(r"^servee/", include(frontendadmin.site.urls)),
 
-At this point, you're really going to want to get into the [docs][rtd].
-
-[rtd]: http://django-servee.readthedocs.org/en/latest/index.html
+At this point, you're really going to want to get into the `Read The Docs <http://django-servee.readthedocs.org/en/latest/index.html>`_.

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -40,4 +40,4 @@ It's important to add servee urls, and you probably want to use autodiscover::
     # ...
     url(r"^servee/", include(frontendadmin.site.urls)),
 
-At this point, you're really going to want to get into the `Read The Docs <http://django-servee.readthedocs.org/en/latest/index.html>`_.
+At this point, you're really going to want to get into the `docs <http://django-servee.readthedocs.org/en/latest/index.html>`_.


### PR DESCRIPTION
Frontend admin should call autodiscover directly instead of through the site object. 
